### PR TITLE
Added gtag plugin for conversion tracking

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -26,9 +26,15 @@ module.exports = {
       },
     },
     {
-      resolve: `gatsby-plugin-google-analytics`,
+      resolve: `gatsby-plugin-google-gtag`,
       options: {
-        trackingId: "UA-158909295-1",
+        trackingIds: [
+          "AW-605133217",
+          "UA-158909295-1",
+        ],
+        pluginConfig: {
+          head: true,
+        },
       },
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11724,6 +11724,25 @@
         }
       }
     },
+    "gatsby-plugin-google-gtag": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-gtag/-/gatsby-plugin-google-gtag-2.1.13.tgz",
+      "integrity": "sha512-cpQJowgxgfekAZdkKHxp6iIcOCeC/378wRCNUo+/LJrpEXvGxkyPp31VjBfWKztGRm84ExVF65k5V81TBoZAeg==",
+      "requires": {
+        "@babel/runtime": "^7.11.2",
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
+          "integrity": "sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
     "gatsby-plugin-manifest": {
       "version": "2.4.10",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.4.10.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11705,25 +11705,6 @@
         }
       }
     },
-    "gatsby-plugin-google-analytics": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-2.3.3.tgz",
-      "integrity": "sha512-pOoMUvF4jzVwW9IksJLngG1zBRljCHxfpCczWUoJQBRU3gcy1syq1KBL/MWGXL1ATGrerdBFGJsiIXbFr6Qp2w==",
-      "requires": {
-        "@babel/runtime": "^7.10.2",
-        "minimatch": "3.0.4"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.10.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
-          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        }
-      }
-    },
     "gatsby-plugin-google-gtag": {
       "version": "2.1.13",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-google-gtag/-/gatsby-plugin-google-gtag-2.1.13.tgz",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "classnames": "^2.2.6",
     "gatsby": "^2.22.17",
     "gatsby-cli": "^2.12.42",
-    "gatsby-plugin-google-analytics": "^2.3.3",
     "gatsby-plugin-google-gtag": "^2.1.13",
     "gatsby-plugin-manifest": "^2.4.10",
     "gatsby-plugin-react-helmet": "^3.3.9",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "gatsby": "^2.22.17",
     "gatsby-cli": "^2.12.42",
     "gatsby-plugin-google-analytics": "^2.3.3",
+    "gatsby-plugin-google-gtag": "^2.1.13",
     "gatsby-plugin-manifest": "^2.4.10",
     "gatsby-plugin-react-helmet": "^3.3.9",
     "gatsby-plugin-web-font-loader": "^1.0.4",


### PR DESCRIPTION
Website issue: https://github.com/angelshot/angelshot.ltd/issues/67

- Installed gatsby-plugin-google-gtag as outlined here: https://www.gatsbyjs.com/plugins/gatsby-plugin-google-gtag/

- The gtag doc said the plugin could replace gatsby-plugin-google-analytics, so I moved the tracking ID from that plugin into the google gtag one.

- Used Google Tag Assistant to confirm the plugin worked:
![image](https://user-images.githubusercontent.com/45927665/96386850-08fef980-116c-11eb-9946-14128ea1d724.png)

Should I look into the comment about multiple installations of Global site tag or does it look ok as is?